### PR TITLE
Add Makefile to load environment dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           sudo apt-get -yqq install libpq-dev
           gem install bundler -v 2.2.29
+          bundle update
           bundle install
           bundle exec rails db:create
           bundle exec rails db:migrate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           sudo apt-get -yqq install libpq-dev
           gem install bundler -v 2.2.29
-          bundle update
           bundle install
           bundle exec rails db:create
           bundle exec rails db:migrate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,56 +9,56 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.0.4.7)
-      actionpack (= 6.0.4.7)
+    actioncable (6.0.4.8)
+      actionpack (= 6.0.4.8)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (6.0.4.7)
-      actionpack (= 6.0.4.7)
-      activejob (= 6.0.4.7)
-      activerecord (= 6.0.4.7)
-      activestorage (= 6.0.4.7)
-      activesupport (= 6.0.4.7)
+    actionmailbox (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      activestorage (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
       mail (>= 2.7.1)
-    actionmailer (6.0.4.7)
-      actionpack (= 6.0.4.7)
-      actionview (= 6.0.4.7)
-      activejob (= 6.0.4.7)
+    actionmailer (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      actionview (= 6.0.4.8)
+      activejob (= 6.0.4.8)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.0.4.7)
-      actionview (= 6.0.4.7)
-      activesupport (= 6.0.4.7)
+    actionpack (6.0.4.8)
+      actionview (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (6.0.4.7)
-      actionpack (= 6.0.4.7)
-      activerecord (= 6.0.4.7)
-      activestorage (= 6.0.4.7)
-      activesupport (= 6.0.4.7)
+    actiontext (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      activestorage (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
       nokogiri (>= 1.8.5)
-    actionview (6.0.4.7)
-      activesupport (= 6.0.4.7)
+    actionview (6.0.4.8)
+      activesupport (= 6.0.4.8)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (6.0.4.7)
-      activesupport (= 6.0.4.7)
+    activejob (6.0.4.8)
+      activesupport (= 6.0.4.8)
       globalid (>= 0.3.6)
-    activemodel (6.0.4.7)
-      activesupport (= 6.0.4.7)
-    activerecord (6.0.4.7)
-      activemodel (= 6.0.4.7)
-      activesupport (= 6.0.4.7)
-    activestorage (6.0.4.7)
-      actionpack (= 6.0.4.7)
-      activejob (= 6.0.4.7)
-      activerecord (= 6.0.4.7)
+    activemodel (6.0.4.8)
+      activesupport (= 6.0.4.8)
+    activerecord (6.0.4.8)
+      activemodel (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
+    activestorage (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
       marcel (~> 1.0.0)
-    activesupport (6.0.4.7)
+    activesupport (6.0.4.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -188,7 +188,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.16.0)
+    loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -204,9 +204,9 @@ GEM
     msgpack (1.4.5)
     multi_xml (0.6.0)
     nio4r (2.5.8)
-    nokogiri (1.13.3-x86_64-darwin)
+    nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (3.11.0)
@@ -237,20 +237,20 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-timeout (0.6.0)
-    rails (6.0.4.7)
-      actioncable (= 6.0.4.7)
-      actionmailbox (= 6.0.4.7)
-      actionmailer (= 6.0.4.7)
-      actionpack (= 6.0.4.7)
-      actiontext (= 6.0.4.7)
-      actionview (= 6.0.4.7)
-      activejob (= 6.0.4.7)
-      activemodel (= 6.0.4.7)
-      activerecord (= 6.0.4.7)
-      activestorage (= 6.0.4.7)
-      activesupport (= 6.0.4.7)
+    rails (6.0.4.8)
+      actioncable (= 6.0.4.8)
+      actionmailbox (= 6.0.4.8)
+      actionmailer (= 6.0.4.8)
+      actionpack (= 6.0.4.8)
+      actiontext (= 6.0.4.8)
+      actionview (= 6.0.4.8)
+      activejob (= 6.0.4.8)
+      activemodel (= 6.0.4.8)
+      activerecord (= 6.0.4.8)
+      activestorage (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
       bundler (>= 1.3.0)
-      railties (= 6.0.4.7)
+      railties (= 6.0.4.8)
       sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
@@ -260,9 +260,9 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    railties (6.0.4.7)
-      actionpack (= 6.0.4.7)
-      activesupport (= 6.0.4.7)
+    railties (6.0.4.8)
+      actionpack (= 6.0.4.8)
+      activesupport (= 6.0.4.8)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
@@ -435,6 +435,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
 
@@ -451,7 +452,7 @@ DEPENDENCIES
   ffaker
   geared_pagination
   httparty
-  jbuilder (~> 2.7)
+  jbuilder (~> 2.11, >= 2.11.5)
   jquery-rails
   jsonapi-serializer
   listen (~> 3.2)
@@ -464,14 +465,14 @@ DEPENDENCIES
   rack-cors
   rack-ratelimit
   rack-timeout
-  rails (~> 6.0.3, >= 6.0.3.4)
+  rails (~> 6.0.4, >= 6.0.4.8)
   rails-i18n (~> 6.0.0)
   ransack
   redis
   rqrcode_png!
   rspec-rails
   rubycritic
-  sass-rails (>= 6)
+  sass-rails (>= 6.0.0)
   selenium-webdriver
   serviceworker-rails
   shoulda-matchers (~> 5.0)
@@ -480,12 +481,12 @@ DEPENDENCIES
   spreadsheet_architect
   spring
   spring-watcher-listen (~> 2.0.0)
-  web-console (>= 3.3.0)
+  web-console (>= 4.2.0)
   webdrivers
-  webpacker (~> 4.0)
+  webpacker (~> 4.3, >= 4.3.0)
 
 RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.29
+   2.3.12

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+SO_NAME := $(shell uname -s)
+
+config_environment:
+ifeq ($(SO_NAME),Linux)
+	apt update
+	apt install postgresql
+	apt install postgresql-contrib
+	apt install postgresql-server-dev-all
+	apt install cmake
+	apt install nodejs
+	apt install libpq-dev
+	gem install bundler
+	bundle install
+endif
+ifeq ($(SO_NAME),Darwin)
+	brew install postgresql || brew install postgres
+	brew install postgresql-contrib
+	brew install postgresql-server-dev-all
+	brew install cmake
+	brew install nodejs
+	brew install libpq-dev
+	gem install bundler
+	bundle install
+endif


### PR DESCRIPTION
Create a new file, named `Makefile` that contains the dependencies installation steps, for each OS type.

To install the dependencies, you need type `make config_environment`.